### PR TITLE
add to ActiveSupport::TestCase, if available (Rails support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,18 @@ describe "#method" do
   end
 end
 ```
-
 The ```context``` method is available only in the nested blocks. One cannot use it in the outside most block. I simply do not desire to introduce a new method in ruby ```Kernel``` module
+
+The ```context``` method is also available on ```ActiveSupport::TestCase```, for use within Rails applications.
+
+
+```ruby
+class ActiveSupport::TestCase
+  context "when using Rails" do
+    ...
+  end
+end
+```
 
 ## Contributing
 

--- a/lib/minitest-spec-context.rb
+++ b/lib/minitest-spec-context.rb
@@ -7,3 +7,11 @@ module MiniTest
     end
   end
 end
+
+if defined? ActiveSupport::TestCase
+  class ActiveSupport::TestCase
+    class << self
+      alias_method :context, :describe
+    end
+  end
+end

--- a/minitest-spec-context.gemspec
+++ b/minitest-spec-context.gemspec
@@ -11,5 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "minitest-spec-context"
   gem.require_paths = ["lib"]
-  gem.version       = '0.0.3'
+  gem.version       = '0.0.4'
+
+  gem.add_development_dependency "activesupport", "~> 6.0"
 end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -1,8 +1,21 @@
 require 'rubygems'
 require 'minitest/autorun'
 require_relative '../lib/minitest-spec-context'
+require 'active_support'
+require 'active_support/test_case'
 
 describe MiniTest::Spec do
+  describe ".context" do
+    let(:object) { "44" }
+    context "when nested with context method" do
+      it "has the access to the variables defined outside" do
+        object.must_equal "44"
+      end
+    end
+  end
+end
+
+class ActiveSupport::TestCase
   describe ".context" do
     let(:object) { "44" }
     context "when nested with context method" do


### PR DESCRIPTION
This enables this to work out of the box with Rails (with https://github.com/ywen/minitest-spec-context).

Also bumps the minor version from v0.0.3 to v0.0.4.